### PR TITLE
Add hoomd simulation code to an operation in project.py

### DIFF
--- a/project/src/project.py
+++ b/project/src/project.py
@@ -12,14 +12,17 @@ class Project(flow.FlowProject):
 @Project.pre(lambda j: j.sp.simulation_engine=='hoomd')
 def run_hoomd(job):
     from mbuild.formats.gsdwriter import write_gsd
+    from mbuild.formats.hoomd3_simulation import create_hoomd3_forcefield
     import hoomd
     import hoomd.md
-    filled_box = get_system(job)z
+    filled_box = get_system(job)
     ff_file = get_ff_file(job)
     ff = foyer.Forcefield(ff_file)
     structure = ff.apply(filled_box)
 
     write_gsd(structure, job.fn('init.gsd'), ref_distance=rd, ref_energy=re)
+    # NOTE: create_hoomd3_forcefield depends on PR
+    # https://github.com/mosdef-hub/mbuild/pull/871
     snapshot, forcefield, ref_vals = create_hoomd3_forcefield(structure,
             ref_distance=10, ref_energy=1/4.184)
 


### PR DESCRIPTION
I'm opening this to get the ball rolling on writing our simulation scripts. It looks like we currently have it laid out where the simulation engine will be a statepoint parameter. If we keep it like that, then we can have the appropriate `run` operations for each engine, which is the way I've started setting the project file up. 