### PR TITLE
Include SPC/E water model and forcefield XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,3 @@ mamba install -c conda-forge pre-commit
 pre-commit install --install-hooks
 pre-commit run --all-files
 ```
-

--- a/project/src/dashboard.py
+++ b/project/src/dashboard.py
@@ -1,14 +1,23 @@
+"""Signac project visualization support using signac-dashboard."""
 from signac_dashboard import Dashboard
-from signac_dashboard.modules import StatepointList, ImageViewer, VideoViewer
-from signac_dashboard.modules import Notes, TextDisplay
+from signac_dashboard.modules import (
+    ImageViewer,
+    Notes,
+    StatepointList,
+    TextDisplay,
+    VideoViewer,
+)
 
 
 class PlotDashboard(Dashboard):
+    """Take signac dashboard and plot statepoints."""
+
     def job_sorter(self, job):
+        """Accumulate all jobs according to a statepoint."""
         return [job.sp.simulation_engine]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     modules = []
     modules.append(StatepointList())
     PlotDashboard(modules=modules).main()

--- a/project/src/project.py
+++ b/project/src/project.py
@@ -1,55 +1,60 @@
 """Setup for signac, signac-flow, signac-dashboard for this study."""
 import flow
-from flow import environments
 import foyer
+from flow import environments
 
 
 class Project(flow.FlowProject):
+    """Base signac flow project."""
+
     pass
 
 
 @Project.operation
-@Project.pre(lambda j: j.sp.simulation_engine=='hoomd')
+@Project.pre(lambda j: j.sp.simulation_engine == "hoomd")
 def run_hoomd(job):
-    from mbuild.formats.gsdwriter import write_gsd
-    from mbuild.formats.hoomd3_simulation import create_hoomd3_forcefield
+    """Run hoomd simulation."""
     import hoomd
     import hoomd.md
+    from mbuild.formats.gsdwriter import write_gsd
+    from mbuild.formats.hoomd3_simulation import create_hoomd3_forcefield
+
     filled_box = get_system(job)
     ff_file = get_ff_file(job)
     ff = foyer.Forcefield(ff_file)
     structure = ff.apply(filled_box)
 
-    write_gsd(structure, job.fn('init.gsd'), ref_distance=rd, ref_energy=re)
+    write_gsd(structure, job.fn("init.gsd"), ref_distance=rd, ref_energy=re)
     # NOTE: create_hoomd3_forcefield depends on PR
     # https://github.com/mosdef-hub/mbuild/pull/871
-    snapshot, forcefield, ref_vals = create_hoomd3_forcefield(structure,
-            ref_distance=10, ref_energy=1/4.184)
+    snapshot, forcefield, ref_vals = create_hoomd3_forcefield(
+        structure, ref_distance=10, ref_energy=1 / 4.184
+    )
 
     device = hoomd.device.auto_select()
     simulation = hoomd.Simulation(device=device, seed=job.sp.replica)
     simulation.create_state_from_snapshot(snapshot)
-    gsd_writer = hoomd.write.GSD(filename=job.fn('traj.gsd'),
-            trigger=hoomd.trigger.Periodic(10000),
-            mode='ab')
+    gsd_writer = hoomd.write.GSD(
+        filename=job.fn("traj.gsd"),
+        trigger=hoomd.trigger.Periodic(10000),
+        mode="ab",
+    )
     simulation.operations.writers.append(gsd_writer)
     integrator = hoomd.md.Integrator(dt=0.005)
     integrator.forces = forcefield
     nvt = hoomd.md.metehods.NVT(
-            filter=hoomd.filter.All(),
-            kT=job.sp.temperature,
-            tau=1.0
+        filter=hoomd.filter.All(), kT=job.sp.temperature, tau=1.0
     )
     integrator.methods = [nvt]
     simulation.operations.intgrator = integrator
     simulation.state.thermalize_particle_momenta(
-            filter=hoomd.filter.All(),
-            kT=job.sp.temperature,
+        filter=hoomd.filter.All(),
+        kT=job.sp.temperature,
     )
     simulation.run(1e6)
     return None
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pr = Project()
     pr.main()

--- a/project/src/xmls/spce.xml
+++ b/project/src/xmls/spce.xml
@@ -1,0 +1,22 @@
+<ForceField version="0.0.1" name="SPC/E Water" combining_rule="geometric">
+ <AtomTypes>
+   <Type name="opls-116" class="OW" element="O" mass="15.99940" def="[O;X2](H)(H)" desc="SPC/E Oxygen" doi="10.1021/j100308a038"/>
+   <!-- Need to validate the Hydrogen SMARTS string below -->
+   <Type name="opls-117" class="HW" element="H" mass="1.00800" def="[H;X1][O;X2](H)" desc="SPC/E Hydrogen" doi="10.1021/j100308a038"/>
+ </AtomTypes>
+ <HarmonicBondForce>
+   <!-- https://github.com/gromacs/gromacs/blob/master/share/top/oplsaa.ff/spce.itp -->
+   <Bond class1="OW" class2="HW" length="0.100" k="345000.0"/>
+ </HarmonicBondForce>
+ <HarmonicAngleForce>
+   <!-- https://github.com/gromacs/gromacs/blob/master/share/top/oplsaa.ff/spce.itp -->
+   <!-- numpy.deg2rad(109.47).round(8) -->
+   <!-- numpy.__version__ 1.21.1 -->
+   <Angle class1="HW" class2="OW" class3="HW" angle="1.91061193" k="383.0"/>
+ </HarmonicAngleForce>
+ <NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
+   <!-- https://github.com/gromacs/gromacs/blob/master/share/top/oplsaa.ff/spce.itp -->
+  <Atom type="opls-116" charge="-0.8476" sigma="0.316557" epsilon="0.650194"/>
+  <Atom type="opls-117" charge="0.4238" sigma="0.0" epsilon="0.0"/>
+ </NonbondedForce>
+</ForceField>

--- a/project/tests/base_test.py
+++ b/project/tests/base_test.py
@@ -1,5 +1,8 @@
+import foyer
 import pytest
 
 
 class BaseTest:
-    pass
+    @pytest.fixture
+    def spceff(self, name="spce.xml"):
+        return foyer.Forcefield(forcefield_files="../src/xmls/" + name)

--- a/project/tests/test_spce_water.py
+++ b/project/tests/test_spce_water.py
@@ -1,0 +1,111 @@
+import numpy as np
+import pytest
+from mbuild.lib.molecules.water import WaterSPC
+
+from project.tests.base_test import BaseTest
+
+
+class TestSPCE(BaseTest):
+    def test_distance(self):
+        spce = WaterSPC()
+        assert len([part for part in spce.particles()]) == 3
+        parthw1 = [part for part in spce.particles_by_name("HW1")]
+        parthw2 = [part for part in spce.particles_by_name("HW2")]
+        partow1 = [part for part in spce.particles_by_name("OW")]
+        assert np.all(
+            np.isclose(np.linalg.norm(parthw1[0].xyz - partow1[0].xyz), 0.1)
+        )
+        assert np.all(
+            np.isclose(np.linalg.norm(parthw2[0].xyz - partow1[0].xyz), 0.1)
+        )
+        assert np.all(
+            np.isclose(
+                np.linalg.norm(parthw1[0].xyz - parthw2[0].xyz).round(4),
+                0.16330,
+            )
+        )
+
+    def test_param_success(self, spceff):
+        spceff.apply(WaterSPC())
+
+    def test_parameters(self, spceff):
+        param_struct = spceff.apply(WaterSPC())
+
+        opls_116 = spceff.get_parameters("atoms", key="opls-116")
+        opls_117 = spceff.get_parameters("atoms", key="opls-117")
+        oh_bond = spceff.get_parameters(
+            "harmonic_bonds", key=["HW", "OW"], keys_are_atom_classes=True
+        )
+        hoh_angle = spceff.get_parameters(
+            "harmonic_angles",
+            key=["HW", "OW", "HW"],
+            keys_are_atom_classes=True,
+        )
+
+        assert "geometric" == param_struct.combining_rule
+        assert np.all(
+            np.isclose(
+                opls_116["sigma"], param_struct.atoms[0].atom_type.sigma / 10
+            )
+        )
+        assert np.all(
+            np.isclose(
+                opls_116["epsilon"],
+                param_struct.atoms[0].atom_type.epsilon * 4.184,
+            )
+        )
+        assert np.all(
+            np.isclose(opls_116["charge"], param_struct.atoms[0].charge)
+        )
+
+        assert np.all(
+            np.isclose(
+                opls_117["sigma"], param_struct.atoms[1].atom_type.sigma / 10
+            )
+        )
+        assert np.all(
+            np.isclose(
+                opls_117["epsilon"],
+                param_struct.atoms[1].atom_type.epsilon * 4.184,
+            )
+        )
+        assert np.all(
+            np.isclose(opls_117["charge"], param_struct.atoms[1].charge)
+        )
+
+        assert np.all(
+            np.isclose(
+                opls_117["sigma"], param_struct.atoms[2].atom_type.sigma / 10
+            )
+        )
+        assert np.all(
+            np.isclose(
+                opls_117["epsilon"],
+                param_struct.atoms[2].atom_type.epsilon * 4.184,
+            )
+        )
+        assert np.all(
+            np.isclose(opls_117["charge"], param_struct.atoms[2].charge)
+        )
+
+        assert np.all(
+            np.isclose(
+                oh_bond["k"],
+                param_struct.bond_types[0].k * (4.184 * 2 / (0.1 ** 2)),
+            )
+        )
+        assert np.all(
+            np.isclose(oh_bond["length"], param_struct.bond_types[0].req / 10)
+        )
+
+        assert np.all(
+            np.isclose(
+                hoh_angle["theta"],
+                np.deg2rad(param_struct.angle_types[0].theteq).round(8),
+            )
+        )
+        assert np.all(
+            np.isclose(
+                hoh_angle["k"], param_struct.angle_types[0].k * 4.184 * 2
+            )
+        )


### PR DESCRIPTION
This includes the foyer xml for SPC/E water and tests to ensure that a
water molecule is being properly parametrized.

Tests are included on a single water molecule to ensure that not only
are the unit conversions are what we expect, we use the
foyer.forcefield.get_parameters method to access the forcefield
information programmatically.

This is a template layout for other molecules and forcefields if needed.