### PR TITLE
Include setuptools install files

### DIFF
--- a/reproducibility_project/src/analysis/__init__.py
+++ b/reproducibility_project/src/analysis/__init__.py
@@ -1,0 +1,4 @@
+"""Analysis routines and helper methods."""
+from reproducibility_project.src.analysis.equlibration import *
+from reproducibility_project.src.analysis.rdf import gsd_rdf
+from reproducibility_project.src.analysis.sampler import sample_job

--- a/reproducibility_project/src/engine_input/cassandra/__init__.py
+++ b/reproducibility_project/src/engine_input/cassandra/__init__.py
@@ -1,0 +1,1 @@
+"""Cassandra engine input module."""

--- a/reproducibility_project/src/engine_input/gomc/__init__.py
+++ b/reproducibility_project/src/engine_input/gomc/__init__.py
@@ -1,0 +1,1 @@
+"""GOMC project."""

--- a/reproducibility_project/src/engine_input/lammps/submission_scripts/__init__.py
+++ b/reproducibility_project/src/engine_input/lammps/submission_scripts/__init__.py
@@ -1,0 +1,1 @@
+"""LAMMPS submission scripts."""

--- a/reproducibility_project/src/engine_input/mcccs/__init__.py
+++ b/reproducibility_project/src/engine_input/mcccs/__init__.py
@@ -1,0 +1,1 @@
+"""MCCCS input module."""

--- a/reproducibility_project/src/engines/__init__.py
+++ b/reproducibility_project/src/engines/__init__.py
@@ -1,1 +1,1 @@
-"""Docstring."""
+"""Per-engine signac projects and additional information."""

--- a/reproducibility_project/src/engines/cassandra/__init__.py
+++ b/reproducibility_project/src/engines/cassandra/__init__.py
@@ -1,0 +1,1 @@
+"""Cassandra project module."""

--- a/reproducibility_project/src/engines/gomc/__init__.py
+++ b/reproducibility_project/src/engines/gomc/__init__.py
@@ -1,0 +1,1 @@
+"""GOMC project module."""

--- a/reproducibility_project/src/engines/gromacs/__init__.py
+++ b/reproducibility_project/src/engines/gromacs/__init__.py
@@ -1,0 +1,1 @@
+"""GROMACS project module."""

--- a/reproducibility_project/src/engines/gromacs/project.py
+++ b/reproducibility_project/src/engines/gromacs/project.py
@@ -5,7 +5,6 @@ import pathlib
 import flow
 from flow import environments
 
-import reproducibility_project
 from reproducibility_project.src.engine_input.gromacs import mdp
 
 

--- a/reproducibility_project/src/engines/hoomd/__init__.py
+++ b/reproducibility_project/src/engines/hoomd/__init__.py
@@ -1,0 +1,1 @@
+"""HOOMD project module."""

--- a/reproducibility_project/src/engines/lammps/__init__.py
+++ b/reproducibility_project/src/engines/lammps/__init__.py
@@ -1,0 +1,1 @@
+"""LAMMPS project module."""

--- a/reproducibility_project/src/engines/mcccs/__init__.py
+++ b/reproducibility_project/src/engines/mcccs/__init__.py
@@ -1,0 +1,1 @@
+"""MCCCS project module."""

--- a/reproducibility_project/tests/base_test.py
+++ b/reproducibility_project/tests/base_test.py
@@ -5,8 +5,7 @@ import pytest
 import signac
 
 from reproducibility_project.src import xmls
-
-from .utils import create_gsd
+from reproducibility_project.tests.utils import create_gsd
 
 
 class BaseTest:

--- a/reproducibility_project/tests/test_equilbration.py
+++ b/reproducibility_project/tests/test_equilbration.py
@@ -6,8 +6,7 @@ from reproducibility_project.src.analysis.equlibration import (
     is_equilibrated,
     trim_non_equilibrated,
 )
-
-from .base_test import BaseTest
+from reproducibility_project.tests.base_test import BaseTest
 
 
 class TestEquilibration(BaseTest):

--- a/reproducibility_project/tests/test_methane_ua.py
+++ b/reproducibility_project/tests/test_methane_ua.py
@@ -1,6 +1,5 @@
 import mbuild as mb
 import numpy as np
-import pytest
 
 from reproducibility_project.src.molecules.methane_ua import MethaneUA
 from reproducibility_project.tests.base_test import BaseTest

--- a/reproducibility_project/tests/test_pentane_ua.py
+++ b/reproducibility_project/tests/test_pentane_ua.py
@@ -1,7 +1,5 @@
-import foyer
 import mbuild as mb
 import numpy as np
-import pytest
 
 from reproducibility_project.src.molecules.pentane_ua import PentaneUA
 from reproducibility_project.tests.base_test import BaseTest

--- a/reproducibility_project/tests/test_rdf.py
+++ b/reproducibility_project/tests/test_rdf.py
@@ -1,7 +1,5 @@
 import freud
-import mbuild as mb
 import numpy as np
-import pytest
 
 from reproducibility_project.src.analysis.rdf import _gsd_rdf, gsd_rdf
 from reproducibility_project.tests.base_test import BaseTest

--- a/reproducibility_project/tests/test_sampler.py
+++ b/reproducibility_project/tests/test_sampler.py
@@ -1,11 +1,9 @@
-import numpy as np
 import pytest
 from pymbar import testsystems
 
 from reproducibility_project.src.analysis.equlibration import is_equilibrated
 from reproducibility_project.src.analysis.sampler import _decorr_sampling
-
-from .base_test import BaseTest
+from reproducibility_project.tests.base_test import BaseTest
 
 
 class TestSampler(BaseTest):

--- a/reproducibility_project/tests/test_spce_water.py
+++ b/reproducibility_project/tests/test_spce_water.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from mbuild.lib.molecules.water import WaterSPC
 
 from reproducibility_project.tests.base_test import BaseTest

--- a/reproducibility_project/tests/test_system_builder.py
+++ b/reproducibility_project/tests/test_system_builder.py
@@ -1,4 +1,3 @@
-import reproducibility_project
 from reproducibility_project.src.molecules.system_builder import (
     construct_system,
 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,12 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools", "wheel"]  # PEP 508 specifications.
+build-backend = "setuptools.build_meta"
+
+[metadata]
+name = reproducibility_study
+version = 0.0.1
+description = MoSDeF collaborative reproducibility study and test case
+
+[options]
+packages=find:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+"""Shim for pyproject.toml files to have --editable installs."""
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
To assist in the installation process and make the project easier to
access, additional __init__.py files and a setup.cfg and setup.py files
were added.

Users can now run
`pip install --editable .` to install this project in an editable mode,
this should make accessing certain directory locations in the project
less "hacky".