### PR TITLE
Feat/neff as equilibration option

### DIFF
--- a/reproducibility_project/src/analysis/equilibration.py
+++ b/reproducibility_project/src/analysis/equilibration.py
@@ -10,7 +10,11 @@ from signac.contrib.job import Job
 
 
 def is_equilibrated(
-        a_t: npt.ArrayLike, threshold_fraction: float = 0.8, threshold_neff: int = 100, nskip: int = 1,) -> List:
+    a_t: npt.ArrayLike,
+    threshold_fraction: float = 0.8,
+    threshold_neff: int = 100,
+    nskip: int = 1,
+) -> List:
     """Check if a dataset is equilibrated based on a fraction of equil data.
 
     Using `pymbar.timeseries` module, check if a timeseries dataset has enough
@@ -45,8 +49,9 @@ def is_equilibrated(
 
     threshold_neff = int(threshold_neff)
     if threshold_neff < 1:
-        raise ValueError(f"Passed 'threshold_neff' value: {threshold_neff}, expected value 1 or greater.")
-
+        raise ValueError(
+            f"Passed 'threshold_neff' value: {threshold_neff}, expected value 1 or greater."
+        )
 
     [t0, g, Neff] = timeseries.detectEquilibration(a_t, nskip=nskip)
     frac_equilibrated = 1.0 - (t0 / np.shape(a_t)[0])
@@ -58,7 +63,10 @@ def is_equilibrated(
 
 
 def trim_non_equilibrated(
-        a_t: npt.ArrayLike, threshold_fraction: float = 0.75, threshold_neff: int = 100, nskip: int = 1
+    a_t: npt.ArrayLike,
+    threshold_fraction: float = 0.75,
+    threshold_neff: int = 100,
+    nskip: int = 1,
 ) -> List:
     """Prune timeseries array to just the production data.
 
@@ -89,7 +97,10 @@ def trim_non_equilibrated(
 
     """
     [truth, t0, g, Neff] = is_equilibrated(
-        a_t, threshold_fraction=threshold_fraction, threshold_neff=threshold_neff, nskip=nskip
+        a_t,
+        threshold_fraction=threshold_fraction,
+        threshold_neff=threshold_neff,
+        nskip=nskip,
     )
     if not truth:
         raise ValueError(

--- a/reproducibility_project/src/analysis/equilibration.py
+++ b/reproducibility_project/src/analysis/equilibration.py
@@ -10,14 +10,13 @@ from signac.contrib.job import Job
 
 
 def is_equilibrated(
-    a_t: npt.ArrayLike, threshold: float = 0.8, nskip: int = 1
-) -> List:
+        a_t: npt.ArrayLike, threshold_fraction: float = 0.8, threshold_neff: int = 100, nskip: int = 1,) -> List:
     """Check if a dataset is equilibrated based on a fraction of equil data.
 
     Using `pymbar.timeseries` module, check if a timeseries dataset has enough
-    equilibrated data based on a threshold value. The threshold value
+    equilibrated data based on one or two threshold values. The threshold_fraction value
     translates to the fraction of total data from the dataset 'a_t' that
-    can be thought of as being in the 'production' region.
+    can be thought of as being in the 'production' region. The threshold_neff is the minimum amount of effectively uncorrelated samples to have in a_t to consider it equilibrated.
 
     The `pymbar.timeseries` module returns the starting index of the
     'production' region from 'a_t'. The fraction of 'production' data is
@@ -29,30 +28,37 @@ def is_equilibrated(
     ----------
     a_t : numpy.typing.Arraylike
         1-D time dependent data to check for equilibration.
-    threshold : float, optional, default=0.8
+    threshold_fraction : float, optional, default=0.8
         Fraction of data expected to be equilibrated.
+    threshold_neff : int, optional, default=100
+        Minimum amount of effectively correlated samples to consider a_t 'equilibrated'.
     nskip : int, optional, default=1
         Since the statistical inefficiency is computed for every time origin
         in a call to timeseries.detectEquilibration, for larger datasets
         (> few hundred), increasing nskip might speed this up, while
         discarding more data.
     """
-    if threshold < 0.0 or threshold > 1.0:
+    if threshold_fraction < 0.0 or threshold_fraction > 1.0:
         raise ValueError(
-            f"Passed 'threshold' value: {threshold}, expected value between 0.0-1.0."
+            f"Passed 'threshold_fraction' value: {threshold_fraction}, expected value between 0.0-1.0."
         )
+
+    threshold_neff = int(threshold_neff)
+    if threshold_neff < 1:
+        raise ValueError(f"Passed 'threshold_neff' value: {threshold_neff}, expected value 1 or greater.")
+
 
     [t0, g, Neff] = timeseries.detectEquilibration(a_t, nskip=nskip)
     frac_equilibrated = 1.0 - (t0 / np.shape(a_t)[0])
 
-    if frac_equilibrated >= threshold:
+    if (frac_equilibrated >= threshold_fraction) and (Neff >= threshold_neff):
         return [True, t0, g, Neff]
     else:
         return [False, None, None, None]
 
 
 def trim_non_equilibrated(
-    a_t: npt.ArrayLike, threshold: float = 0.75, nskip: int = 1
+        a_t: npt.ArrayLike, threshold_fraction: float = 0.75, threshold_neff: int = 100, nskip: int = 1
 ) -> List:
     """Prune timeseries array to just the production data.
 
@@ -71,8 +77,10 @@ def trim_non_equilibrated(
     ----------
     a_t : numpy.typing.Arraylike
         1-D time dependent data to check for equilibration.
-    threshold : float, optional, default=0.8
+    threshold_fraction : float, optional, default=0.75
         Fraction of data expected to be equilibrated.
+    threshold_neff : int, optional, default=100
+        Minimum amount of uncorrelated samples.
     nskip : int, optional, default=1
         Since the statistical inefficiency is computed for every time origin
         in a call to timeseries.detectEquilibration, for larger datasets
@@ -81,11 +89,11 @@ def trim_non_equilibrated(
 
     """
     [truth, t0, g, Neff] = is_equilibrated(
-        a_t, threshold=threshold, nskip=nskip
+        a_t, threshold_fraction=threshold_fraction, threshold_neff=threshold_neff, nskip=nskip
     )
     if not truth:
         raise ValueError(
-            f"Data with a threshold of {threshold} is not equilibrated!"
+            f"Data with a threshold_fraction of {threshold_fraction} and threshold_neff {threshold_neff} is not equilibrated!"
         )
 
     return [a_t[t0:], t0, g, Neff]
@@ -97,7 +105,8 @@ def plot_job_property_with_t0(
     property_name: str,
     title: str = None,
     vline_scale: float = 1.1,
-    threshold: float = 0.0,
+    threshold_fraction: float = 0.0,
+    threshold_neff: int = 1,
     overwrite: bool = False,
     data_plt_kwargs: dict = None,
     vline_plt_kwargs: dict = None,
@@ -117,8 +126,10 @@ def plot_job_property_with_t0(
         Title of the plot
     vline_scale : float, optional, default=1.1
         Scale the min and max components of the vertical line.
-    threshold : float, optional, default=0.0
-        Threshold to error out on if threshold fraction of data is not equilibrated.
+    threshold_fraction : float, optional, default=0.0
+        Fraction of data expected to be equilibrated.
+    threshold_neff : int, optional, default=1
+        Minimum amount of uncorrelated samples.
     overwrite : bool, optional, default=False
         Do not write to filename if a file already exists with the same name.
         Set to True to overwrite exisiting files.
@@ -149,7 +160,8 @@ def plot_job_property_with_t0(
             vline_scale=vline_scale,
             title=title,
             overwrite=overwrite,
-            threshold=threshold,
+            threshold_fraction=threshold_fraction,
+            threshold_neff=threshold_neff,
             data_plt_kwargs=data_plt_kwargs,
             vline_plt_kwargs=vline_plt_kwargs,
         )

--- a/reproducibility_project/src/analysis/equilibration.py
+++ b/reproducibility_project/src/analysis/equilibration.py
@@ -18,7 +18,7 @@ def is_equilibrated(
     """Check if a dataset is equilibrated based on a fraction of equil data.
 
     Using `pymbar.timeseries` module, check if a timeseries dataset has enough
-    equilibrated data based on one or two threshold values. The threshold_fraction value
+    equilibrated data based on two threshold values. The threshold_fraction value
     translates to the fraction of total data from the dataset 'a_t' that
     can be thought of as being in the 'production' region. The threshold_neff is the minimum amount of effectively uncorrelated samples to have in a_t to consider it equilibrated.
 

--- a/reproducibility_project/src/analysis/sampler.py
+++ b/reproducibility_project/src/analysis/sampler.py
@@ -6,7 +6,7 @@ from pymbar import timeseries
 from reproducibility_project.src.analysis.equilibration import is_equilibrated
 
 
-def sample_job(job, variable="potential_energy", threshold=0.75):
+def sample_job(job, variable="potential_energy", threshold_fraction=0.75, threshold_neff=100):
     """Use the timeseries module from pymbar to perform statistical sampling.
 
     The start, end and decorrleated step size of the production region are
@@ -18,8 +18,10 @@ def sample_job(job, variable="potential_energy", threshold=0.75):
         The Job object.
     variable : str; default "potential_energy"
         The variable to be used in sampling.
-    threshold : float, optional, default=0.75
+    threshold_fraction : float, optional, default=0.75
         Fraction of data expected to be equilibrated.
+    threshold_neff : int, optional, default=100
+        Minimum amount of uncorrelated samples to be considered equilibrated
     """
     try:
         job.doc["sampling_results"]
@@ -27,22 +29,24 @@ def sample_job(job, variable="potential_energy", threshold=0.75):
         job.doc["sampling_results"] = {}
 
     data = np.genfromtxt(job.fn("log.txt"), names=True)[variable]
-    start, stop, step, Neff = _decorr_sampling(data, threshold)
+    start, stop, step, Neff = _decorr_sampling(data, threshold_fraction=threshold_fraction, threshold_neff=threshold_neff)
     job.doc["sampling_results"][variable] = (range(start, stop, step), Neff)
 
 
-def _decorr_sampling(data, threshold):
+def _decorr_sampling(data, threshold_fraction=0.75, threshold_neff=100):
     """Use the timeseries module from pymbar to perform statistical sampling.
 
     Parameters
     ----------
     data : numpy.Array
         1-D time dependent data to check for equilibration
-    threshold : float
+    threshold_fraction : float, default=0.75
         Fraction of data expected to be equilibrated.
+    threshold_neff : int, default=100
+        Minimum amount of uncorrelated samples to be considered equilibrated
     """
     is_equil, prod_start, ineff, Neff = is_equilibrated(
-        data, threshold, nskip=1
+        data, threshold_fraction=threshold_fraction, threshold_neff=threshold_neff, nskip=1
     )
     if is_equil:
         uncorr_indices = timeseries.subsampleCorrelatedData(

--- a/reproducibility_project/src/analysis/sampler.py
+++ b/reproducibility_project/src/analysis/sampler.py
@@ -6,7 +6,12 @@ from pymbar import timeseries
 from reproducibility_project.src.analysis.equilibration import is_equilibrated
 
 
-def sample_job(job, variable="potential_energy", threshold_fraction=0.75, threshold_neff=100):
+def sample_job(
+    job,
+    variable="potential_energy",
+    threshold_fraction=0.75,
+    threshold_neff=100,
+):
     """Use the timeseries module from pymbar to perform statistical sampling.
 
     The start, end and decorrleated step size of the production region are
@@ -29,7 +34,11 @@ def sample_job(job, variable="potential_energy", threshold_fraction=0.75, thresh
         job.doc["sampling_results"] = {}
 
     data = np.genfromtxt(job.fn("log.txt"), names=True)[variable]
-    start, stop, step, Neff = _decorr_sampling(data, threshold_fraction=threshold_fraction, threshold_neff=threshold_neff)
+    start, stop, step, Neff = _decorr_sampling(
+        data,
+        threshold_fraction=threshold_fraction,
+        threshold_neff=threshold_neff,
+    )
     job.doc["sampling_results"][variable] = (range(start, stop, step), Neff)
 
 
@@ -46,7 +55,10 @@ def _decorr_sampling(data, threshold_fraction=0.75, threshold_neff=100):
         Minimum amount of uncorrelated samples to be considered equilibrated
     """
     is_equil, prod_start, ineff, Neff = is_equilibrated(
-        data, threshold_fraction=threshold_fraction, threshold_neff=threshold_neff, nskip=1
+        data,
+        threshold_fraction=threshold_fraction,
+        threshold_neff=threshold_neff,
+        nskip=1,
     )
     if is_equil:
         uncorr_indices = timeseries.subsampleCorrelatedData(

--- a/reproducibility_project/src/utils/plotting.py
+++ b/reproducibility_project/src/utils/plotting.py
@@ -47,7 +47,12 @@ def plot_data_with_t0_line(
             f"Cannot write {path.name}, file already exists at: {path.absolute()}. Set overwrite=True to replace file."
         )
 
-    _, t0, g, Neff = is_equilibrated(a_t, threshold_fraction=threshold_fraction, threshold_neff=threshold_neff, nskip=1)
+    _, t0, g, Neff = is_equilibrated(
+        a_t,
+        threshold_fraction=threshold_fraction,
+        threshold_neff=threshold_neff,
+        nskip=1,
+    )
 
     ymin = np.min(a_t) - np.min(a_t) * (np.abs(1 - vline_scale))
     ymax = np.max(a_t) + np.max(a_t) * (np.abs(1 - vline_scale))

--- a/reproducibility_project/src/utils/plotting.py
+++ b/reproducibility_project/src/utils/plotting.py
@@ -12,7 +12,8 @@ def plot_data_with_t0_line(
     filename: str,
     a_t: npt.ArrayLike,
     vline_scale: float = 1.1,
-    threshold: float = 0.0,
+    threshold_fraction: float = 0.0,
+    threshold_neff: int = 1,
     overwrite: bool = False,
     title: str = None,
     data_plt_kwargs: dict = None,
@@ -26,8 +27,10 @@ def plot_data_with_t0_line(
         1-D time dependent data
     vline_scale : float, optional, default=1.1
         Scale the min and max components of the vertical line.
-    threshold : float, optional, default=0.0
-        Threshold to error out on if threshold fraction of data is not equilibrated.
+    threshold_fraction : float, optional, default=0.0
+        Threshold_fraction to error out on if threshold fraction of data is not equilibrated.
+    threshold_neff : int, optional, default=1
+        Threshold amount of uncorrelated samples to error out on if threshold amount of data is not equilibrated.
     overwrite : bool, optional, default=False
         Do not write to filename if a file already exists with the same name.
         Set to True to overwrite exisiting files.
@@ -44,7 +47,7 @@ def plot_data_with_t0_line(
             f"Cannot write {path.name}, file already exists at: {path.absolute()}. Set overwrite=True to replace file."
         )
 
-    _, t0, g, Neff = is_equilibrated(a_t, threshold=threshold, nskip=1)
+    _, t0, g, Neff = is_equilibrated(a_t, threshold_fraction=threshold_fraction, threshold_neff=threshold_neff, nskip=1)
 
     ymin = np.min(a_t) - np.min(a_t) * (np.abs(1 - vline_scale))
     ymax = np.max(a_t) + np.max(a_t) * (np.abs(1 - vline_scale))

--- a/reproducibility_project/tests/base_test.py
+++ b/reproducibility_project/tests/base_test.py
@@ -3,6 +3,7 @@ import os
 import foyer
 import pytest
 import signac
+from pymbar.testsystems import correlated_timeseries_example
 
 from reproducibility_project.src import xmls
 from reproducibility_project.tests.utils import create_gsd
@@ -19,6 +20,10 @@ class BaseTest:
         filename = tmp_job.fn("trajectory.gsd")
         create_gsd(filename)
         return tmp_job
+
+    @pytest.fixture
+    def correlated_data_tau100_n10000(self):
+        return correlated_timeseries_example(N=10000, tau=100, seed=432)
 
     @pytest.fixture
     def tmp_project(self):

--- a/reproducibility_project/tests/test_equilibration.py
+++ b/reproducibility_project/tests/test_equilibration.py
@@ -1,4 +1,5 @@
 import numpy as np
+from pymbar.testsystems.timeseries import correlated_timeseries_example
 import pytest
 from pymbar import testsystems
 
@@ -10,34 +11,38 @@ from reproducibility_project.tests.base_test import BaseTest
 
 
 class TestEquilibration(BaseTest):
-    def test_is_equilibrated(self):
-        data = testsystems.correlated_timeseries_example(
-            N=1000, tau=200, seed=432
-        )
-        assert not is_equilibrated(data, threshold=0.80)[0]
-        assert not is_equilibrated(data, threshold=0.40)[0]
-        assert is_equilibrated(data, threshold=0.10)[0]
+    def test_is_equilibrated(self, correlated_data_tau100_n10000):
+        data = correlated_data_tau100_n10000
+        assert not is_equilibrated(data, threshold_fraction=0.80, threshold_neff=100)[0]
+        assert not is_equilibrated(data, threshold_fraction=0.40, threshold_neff=100)[0]
+        assert is_equilibrated(data, threshold_fraction=0.10, threshold_neff=1)[0]
 
-    def test_incorrect_threshold(self):
-        data = testsystems.correlated_timeseries_example(
-            N=1000, tau=200, seed=432
-        )
-        with pytest.raises(ValueError, match=r"Passed \'threshold\' value"):
-            is_equilibrated(data, threshold=2.0)
+        assert not is_equilibrated(correlated_data_tau100_n10000, threshold_fraction=0.10, threshold_neff=5000)[0]
+        assert not is_equilibrated(correlated_data_tau100_n10000, threshold_fraction=0.10, threshold_neff=9999)[0]
+        assert is_equilibrated(correlated_data_tau100_n10000, threshold_fraction=0.10, threshold_neff=10)[0]
 
-        with pytest.raises(ValueError, match=r"Passed \'threshold\' value"):
-            is_equilibrated(data, threshold=-2.0)
+    def test_incorrect_threshold_fraction(self, correlated_data_tau100_n10000):
+        with pytest.raises(ValueError, match=r"Passed \'threshold_fraction\' value"):
+            is_equilibrated(correlated_data_tau100_n10000, threshold_fraction=2.0)
 
-    def test_return_trimmed_data(self):
-        data = testsystems.correlated_timeseries_example(
-            N=1000, tau=200, seed=432
-        )
-        [new_a_t, t0, g, Neff] = trim_non_equilibrated(data, threshold=0.2)
+        with pytest.raises(ValueError, match=r"Passed \'threshold_fraction\' value"):
+            is_equilibrated(correlated_data_tau100_n10000, threshold_fraction=-2.0)
+
+    def test_incorrect_threshold_neff(self, correlated_data_tau100_n10000):
+        data = correlated_data_tau100_n10000
+        with pytest.raises(ValueError, match=r"Passed \'threshold_neff\' value"):
+            is_equilibrated(data, threshold_fraction=0.75, threshold_neff=0)
+        with pytest.raises(ValueError, match=r"Passed \'threshold_neff\' value"):
+            is_equilibrated(data, threshold_fraction=0.75, threshold_neff=-1)
+
+    def test_return_trimmed_data(self, correlated_data_tau100_n10000):
+        data = correlated_data_tau100_n10000
+        [new_a_t, t0, g, Neff] = trim_non_equilibrated(data, threshold_fraction=0.2, threshold_neff=10)
         assert np.shape(new_a_t)[0] < np.shape(data)[0]
 
-    def test_trim_high_threshold(self):
-        data = testsystems.correlated_timeseries_example(
-            N=10000, tau=200, seed=432
-        )
-        with pytest.raises(ValueError, match=r"Data with a threshold"):
-            [new_a_t, t0, g, Neff] = trim_non_equilibrated(data, threshold=0.98)
+    def test_trim_high_threshold(self, correlated_data_tau100_n10000):
+        data = correlated_data_tau100_n10000
+        with pytest.raises(ValueError, match=r"Data with a threshold_fraction"):
+            [new_a_t, t0, g, Neff] = trim_non_equilibrated(data, threshold_fraction=0.98)
+        with pytest.raises(ValueError, match=r"Data with a threshold\_fraction of 0\.75 and threshold\_neff 10000 is not equilibrated\!"):
+            [new_a_t, t0, g, Neff] = trim_non_equilibrated(data, threshold_fraction=0.75, threshold_neff=10000)

--- a/reproducibility_project/tests/test_equilibration.py
+++ b/reproducibility_project/tests/test_equilibration.py
@@ -1,7 +1,7 @@
 import numpy as np
-from pymbar.testsystems.timeseries import correlated_timeseries_example
 import pytest
 from pymbar import testsystems
+from pymbar.testsystems.timeseries import correlated_timeseries_example
 
 from reproducibility_project.src.analysis.equilibration import (
     is_equilibrated,
@@ -13,36 +13,75 @@ from reproducibility_project.tests.base_test import BaseTest
 class TestEquilibration(BaseTest):
     def test_is_equilibrated(self, correlated_data_tau100_n10000):
         data = correlated_data_tau100_n10000
-        assert not is_equilibrated(data, threshold_fraction=0.80, threshold_neff=100)[0]
-        assert not is_equilibrated(data, threshold_fraction=0.40, threshold_neff=100)[0]
-        assert is_equilibrated(data, threshold_fraction=0.10, threshold_neff=1)[0]
+        assert not is_equilibrated(
+            data, threshold_fraction=0.80, threshold_neff=100
+        )[0]
+        assert not is_equilibrated(
+            data, threshold_fraction=0.40, threshold_neff=100
+        )[0]
+        assert is_equilibrated(data, threshold_fraction=0.10, threshold_neff=1)[
+            0
+        ]
 
-        assert not is_equilibrated(correlated_data_tau100_n10000, threshold_fraction=0.10, threshold_neff=5000)[0]
-        assert not is_equilibrated(correlated_data_tau100_n10000, threshold_fraction=0.10, threshold_neff=9999)[0]
-        assert is_equilibrated(correlated_data_tau100_n10000, threshold_fraction=0.10, threshold_neff=10)[0]
+        assert not is_equilibrated(
+            correlated_data_tau100_n10000,
+            threshold_fraction=0.10,
+            threshold_neff=5000,
+        )[0]
+        assert not is_equilibrated(
+            correlated_data_tau100_n10000,
+            threshold_fraction=0.10,
+            threshold_neff=9999,
+        )[0]
+        assert is_equilibrated(
+            correlated_data_tau100_n10000,
+            threshold_fraction=0.10,
+            threshold_neff=10,
+        )[0]
 
     def test_incorrect_threshold_fraction(self, correlated_data_tau100_n10000):
-        with pytest.raises(ValueError, match=r"Passed \'threshold_fraction\' value"):
-            is_equilibrated(correlated_data_tau100_n10000, threshold_fraction=2.0)
+        with pytest.raises(
+            ValueError, match=r"Passed \'threshold_fraction\' value"
+        ):
+            is_equilibrated(
+                correlated_data_tau100_n10000, threshold_fraction=2.0
+            )
 
-        with pytest.raises(ValueError, match=r"Passed \'threshold_fraction\' value"):
-            is_equilibrated(correlated_data_tau100_n10000, threshold_fraction=-2.0)
+        with pytest.raises(
+            ValueError, match=r"Passed \'threshold_fraction\' value"
+        ):
+            is_equilibrated(
+                correlated_data_tau100_n10000, threshold_fraction=-2.0
+            )
 
     def test_incorrect_threshold_neff(self, correlated_data_tau100_n10000):
         data = correlated_data_tau100_n10000
-        with pytest.raises(ValueError, match=r"Passed \'threshold_neff\' value"):
+        with pytest.raises(
+            ValueError, match=r"Passed \'threshold_neff\' value"
+        ):
             is_equilibrated(data, threshold_fraction=0.75, threshold_neff=0)
-        with pytest.raises(ValueError, match=r"Passed \'threshold_neff\' value"):
+        with pytest.raises(
+            ValueError, match=r"Passed \'threshold_neff\' value"
+        ):
             is_equilibrated(data, threshold_fraction=0.75, threshold_neff=-1)
 
     def test_return_trimmed_data(self, correlated_data_tau100_n10000):
         data = correlated_data_tau100_n10000
-        [new_a_t, t0, g, Neff] = trim_non_equilibrated(data, threshold_fraction=0.2, threshold_neff=10)
+        [new_a_t, t0, g, Neff] = trim_non_equilibrated(
+            data, threshold_fraction=0.2, threshold_neff=10
+        )
         assert np.shape(new_a_t)[0] < np.shape(data)[0]
 
     def test_trim_high_threshold(self, correlated_data_tau100_n10000):
         data = correlated_data_tau100_n10000
         with pytest.raises(ValueError, match=r"Data with a threshold_fraction"):
-            [new_a_t, t0, g, Neff] = trim_non_equilibrated(data, threshold_fraction=0.98)
-        with pytest.raises(ValueError, match=r"Data with a threshold\_fraction of 0\.75 and threshold\_neff 10000 is not equilibrated\!"):
-            [new_a_t, t0, g, Neff] = trim_non_equilibrated(data, threshold_fraction=0.75, threshold_neff=10000)
+            [new_a_t, t0, g, Neff] = trim_non_equilibrated(
+                data, threshold_fraction=0.98
+            )
+        with pytest.raises(
+            ValueError,
+            match=r"Data with a threshold\_fraction of 0\.75 and threshold\_neff 10000 is not equilibrated\!",
+        ):
+            [new_a_t, t0, g, Neff] = trim_non_equilibrated(
+                data, threshold_fraction=0.75, threshold_neff=10000
+            )

--- a/reproducibility_project/tests/test_sampler.py
+++ b/reproducibility_project/tests/test_sampler.py
@@ -10,14 +10,21 @@ class TestSampler(BaseTest):
     def test_not_equilibrated(self, correlated_data_tau100_n10000):
         data = correlated_data_tau100_n10000
         with pytest.raises(ValueError):
-            start, stop, step = _decorr_sampling(data, threshold_fraction=0.80, threshold_neff=100)
+            start, stop, step = _decorr_sampling(
+                data, threshold_fraction=0.80, threshold_neff=100
+            )
 
     def test_equilibrated(self, correlated_data_tau100_n10000):
         data = correlated_data_tau100_n10000
         is_equil, prod_start, ineff, Neff = is_equilibrated(
-            data, threshold_fraction=0.10, threshold_neff=10, nskip=1,
+            data,
+            threshold_fraction=0.10,
+            threshold_neff=10,
+            nskip=1,
         )
-        start, stop, step, neff_samples = _decorr_sampling(data, threshold_fraction=0.10, threshold_neff=10)
+        start, stop, step, neff_samples = _decorr_sampling(
+            data, threshold_fraction=0.10, threshold_neff=10
+        )
         assert start >= prod_start
         assert step >= ineff
         assert neff_samples > 1

--- a/reproducibility_project/tests/test_sampler.py
+++ b/reproducibility_project/tests/test_sampler.py
@@ -7,21 +7,17 @@ from reproducibility_project.tests.base_test import BaseTest
 
 
 class TestSampler(BaseTest):
-    def test_not_equilibrated(self):
-        data = testsystems.correlated_timeseries_example(
-            N=1000, tau=200, seed=432
-        )
+    def test_not_equilibrated(self, correlated_data_tau100_n10000):
+        data = correlated_data_tau100_n10000
         with pytest.raises(ValueError):
-            start, stop, step = _decorr_sampling(data, threshold=0.80)
+            start, stop, step = _decorr_sampling(data, threshold_fraction=0.80, threshold_neff=100)
 
-    def test_equilibrated(self):
-        data = testsystems.correlated_timeseries_example(
-            N=1000, tau=200, seed=432
-        )
+    def test_equilibrated(self, correlated_data_tau100_n10000):
+        data = correlated_data_tau100_n10000
         is_equil, prod_start, ineff, Neff = is_equilibrated(
-            data, threshold=0.10, nskip=1
+            data, threshold_fraction=0.10, threshold_neff=10, nskip=1,
         )
-        start, stop, step, neff_samples = _decorr_sampling(data, threshold=0.10)
+        start, stop, step, neff_samples = _decorr_sampling(data, threshold_fraction=0.10, threshold_neff=10)
         assert start >= prod_start
         assert step >= ineff
         assert neff_samples > 1


### PR DESCRIPTION
Previously, the only metric in `is_equilibrated` to determine if a set
of data was sufficiently equilibrated was only with a fraction of the
total dataset.

This creates issues when dealing with very small data sets since we also
require a sufficient amount of effectively uncorrelated samples to do
proper statistical treatments. Now, there are two values that need to be
true before we classify a dataset as equilibrated:

1. A fraction of the dataset must be considered effectively decorrelated
(the starting index of the location in the data that is the first
uncorrelated sample)
2. A minimum amount of uncorrelated samples needs to be available based
   on the starting index and the statistical inefficiency of the data.

This PR adds number 2, since number 1 was included in the first
iteration of this method (it has been named from `threshold` to
`threshold_fraction`.
A new function argument, `threshold_neff` has been added, with a default
value of 100.

Now, for `is_equilibrated` to return `True`, it must satisfy both of
these threshold values to be considered equilibrated.