### PR TITLE
Add filenames as kwargs to analysis functions

### DIFF
--- a/reproducibility_project/src/analysis/diffusion.py
+++ b/reproducibility_project/src/analysis/diffusion.py
@@ -9,7 +9,7 @@ from freud.msd import MSD
 from scipy import stats
 
 
-def gsd_msd(job, skip=2, stride=1, unwrapped=False):
+def gsd_msd(job, filename="trajectory.gsd", skip=2, stride=1, unwrapped=False):
     """Compute the MSD and diffusion coefficient given a Signac Job object.
 
     The job folder is expected to contain the file "trajectory.gsd" with lengths
@@ -25,6 +25,9 @@ def gsd_msd(job, skip=2, stride=1, unwrapped=False):
     ----------
     job : signac.contrib.job.Job
         The Job object.
+    filename : str, default "trajectory.gsd"
+        The relative path (from the job directory) to the trajectory file to
+        analyze.
     skip : int, default 2
         The number of frames from the trajectory to skip.
     stride : int, default 1
@@ -40,7 +43,7 @@ def gsd_msd(job, skip=2, stride=1, unwrapped=False):
     freud.msd.MSD
         Computed MSD object
     """
-    msd, timesteps = _gsd_msd(job.fn("trajectory.gsd"), skip, stride, unwrapped)
+    msd, timesteps = _gsd_msd(job.fn(filename), skip, stride, unwrapped)
 
     m, b, r, p, std_err = stats.linregress(timesteps, msd.msd)
 

--- a/reproducibility_project/src/analysis/equilibration.py
+++ b/reproducibility_project/src/analysis/equilibration.py
@@ -18,9 +18,11 @@ def is_equilibrated(
     """Check if a dataset is equilibrated based on a fraction of equil data.
 
     Using `pymbar.timeseries` module, check if a timeseries dataset has enough
-    equilibrated data based on two threshold values. The threshold_fraction value
-    translates to the fraction of total data from the dataset 'a_t' that
-    can be thought of as being in the 'production' region. The threshold_neff is the minimum amount of effectively uncorrelated samples to have in a_t to consider it equilibrated.
+    equilibrated data based on two threshold values. The threshold_fraction
+    value translates to the fraction of total data from the dataset 'a_t' that
+    can be thought of as being in the 'production' region. The threshold_neff
+    is the minimum amount of effectively uncorrelated samples to have in a_t to
+    consider it equilibrated.
 
     The `pymbar.timeseries` module returns the starting index of the
     'production' region from 'a_t'. The fraction of 'production' data is
@@ -35,7 +37,8 @@ def is_equilibrated(
     threshold_fraction : float, optional, default=0.8
         Fraction of data expected to be equilibrated.
     threshold_neff : int, optional, default=100
-        Minimum amount of effectively correlated samples to consider a_t 'equilibrated'.
+        Minimum amount of effectively correlated samples to consider a_t
+        'equilibrated'.
     nskip : int, optional, default=1
         Since the statistical inefficiency is computed for every time origin
         in a call to timeseries.detectEquilibration, for larger datasets
@@ -44,13 +47,15 @@ def is_equilibrated(
     """
     if threshold_fraction < 0.0 or threshold_fraction > 1.0:
         raise ValueError(
-            f"Passed 'threshold_fraction' value: {threshold_fraction}, expected value between 0.0-1.0."
+            f"Passed 'threshold_fraction' value: {threshold_fraction}, "
+            "expected value between 0.0-1.0."
         )
 
     threshold_neff = int(threshold_neff)
     if threshold_neff < 1:
         raise ValueError(
-            f"Passed 'threshold_neff' value: {threshold_neff}, expected value 1 or greater."
+            f"Passed 'threshold_neff' value: {threshold_neff}, expected value "
+            "1 or greater."
         )
 
     [t0, g, Neff] = timeseries.detectEquilibration(a_t, nskip=nskip)
@@ -94,7 +99,6 @@ def trim_non_equilibrated(
         in a call to timeseries.detectEquilibration, for larger datasets
         (> few hundred), increasing nskip might speed this up, while
         discarding more data.
-
     """
     [truth, t0, g, Neff] = is_equilibrated(
         a_t,
@@ -104,7 +108,8 @@ def trim_non_equilibrated(
     )
     if not truth:
         raise ValueError(
-            f"Data with a threshold_fraction of {threshold_fraction} and threshold_neff {threshold_neff} is not equilibrated!"
+            f"Data with a threshold_fraction of {threshold_fraction} and "
+            f"threshold_neff {threshold_neff} is not equilibrated!"
         )
 
     return [a_t[t0:], t0, g, Neff]
@@ -114,6 +119,7 @@ def plot_job_property_with_t0(
     job: Job,
     filename: str,
     property_name: str,
+    log_filename: str = "log.txt",
     title: str = None,
     vline_scale: float = 1.1,
     threshold_fraction: float = 0.0,
@@ -122,7 +128,7 @@ def plot_job_property_with_t0(
     data_plt_kwargs: dict = None,
     vline_plt_kwargs: dict = None,
 ) -> None:
-    """Plot data with a vertical line at beginning of equilibration for a specifc job and property.
+    """Plot data with a vertical line at beginning of equilibration for a specific job and property.
 
     Parameters
     ----------
@@ -130,9 +136,12 @@ def plot_job_property_with_t0(
         The signac job to access the necessary data files.
     filename : str, required
         The name of the output image.
-        Only the name of the file and extension is expected, the location will be within the job.
+        Only the name of the file and extension is expected, the location will
+        be within the job.
     property_name : str, required
         The name of the property to plot.
+    log_filename : str, default "log.txt"
+        The relative path (from the job directory) to the log file name to read.
     title : str, optional, default = Property
         Title of the plot
     vline_scale : float, optional, default=1.1
@@ -147,7 +156,8 @@ def plot_job_property_with_t0(
     data_plt_kwargs : dict, optional, default={}
         Pass in a dictionary of keyword arguments to plot the data.
     vline_plt_kwargs : dict, optional, default={}
-        Pass in a dictionary of keyword arguments for the vertical line denoting t0.
+        Pass in a dictionary of keyword arguments for the vertical line
+        denoting t0.
     """
     from reproducibility_project.src.utils.plotting import (
         plot_data_with_t0_line,
@@ -156,7 +166,7 @@ def plot_job_property_with_t0(
     fname = pathlib.Path(filename)
     fname = fname.name
     a_t = pd.read_csv(
-        job.fn("log.txt"),
+        job.fn(log_filename),
         delim_whitespace=True,
         header=0,
     )

--- a/reproducibility_project/src/analysis/rdf.py
+++ b/reproducibility_project/src/analysis/rdf.py
@@ -7,11 +7,19 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-def gsd_rdf(job, frames=10, stride=1, bins=50, r_min=0.5, r_max=None):
+def gsd_rdf(
+    job,
+    filename="trajectory.gsd",
+    frames=10,
+    stride=1,
+    bins=50,
+    r_min=0.5,
+    r_max=None,
+):
     """Compute the RDF given a Signac Job object.
 
-    The job folder is expected to contain the file "trajectory.gsd" with lengths
-    in nanometers.
+    The job folder is expected to contain a trajectory file with lengths in
+    nanometers.
     This function is a convenience wrapper for freud's RDF module
     https://freud.readthedocs.io/en/latest/modules/density.html#freud.density.RDF
     After execution, the files "rdf.png" and "rdf.txt" are created in the job
@@ -21,6 +29,9 @@ def gsd_rdf(job, frames=10, stride=1, bins=50, r_min=0.5, r_max=None):
     ----------
     job : signac.contrib.job.Job
         The Job object.
+    filename : str, default "trajectory.gsd"
+        The relative path (from the job directory) to the trajectory file to be
+        analyzed.
     frames : int, default 10
         The number of frames from the trajectory to average. Up to and always
         uses the last frame.
@@ -39,7 +50,7 @@ def gsd_rdf(job, frames=10, stride=1, bins=50, r_min=0.5, r_max=None):
     freud.density.RDF
         Computed RDF object
     """
-    rdf = _gsd_rdf(job.fn("trajectory.gsd"), frames, stride, bins, r_min, r_max)
+    rdf = _gsd_rdf(job.fn(filename), frames, stride, bins, r_min, r_max)
 
     fig, ax = plt.subplots()
     ax.plot(rdf.bin_centers, rdf.rdf)

--- a/reproducibility_project/src/analysis/sampler.py
+++ b/reproducibility_project/src/analysis/sampler.py
@@ -8,6 +8,7 @@ from reproducibility_project.src.analysis.equilibration import is_equilibrated
 
 def sample_job(
     job,
+    filename="log.txt",
     variable="potential_energy",
     threshold_fraction=0.75,
     threshold_neff=100,
@@ -21,6 +22,9 @@ def sample_job(
     ----------
     job : signac.contrib.job.Job
         The Job object.
+    filename : str, default "log.txt"
+        The relative path (from the job directory) to the log file to be
+        analyzed.
     variable : str; default "potential_energy"
         The variable to be used in sampling.
     threshold_fraction : float, optional, default=0.75
@@ -33,7 +37,7 @@ def sample_job(
     except KeyError:
         job.doc["sampling_results"] = {}
 
-    data = np.genfromtxt(job.fn("log.txt"), names=True)[variable]
+    data = np.genfromtxt(job.fn(filename), names=True)[variable]
     start, stop, step, Neff = _decorr_sampling(
         data,
         threshold_fraction=threshold_fraction,
@@ -72,7 +76,8 @@ def _decorr_sampling(data, threshold_fraction=0.75, threshold_neff=100):
         )
     else:
         raise ValueError(
-            "Property does not have requisite threshold of production data expected."
-            "More production data is needed, or the threshold needs to be lowered."
-            "See project.src.analysis.equilibration.is_equilibrated for more information."
+            "Property does not have requisite threshold of production data "
+            "expected. More production data is needed, or the threshold needs "
+            "to be lowered. See project.src.analysis.equilibration.is_equilibrated"
+            " for more information."
         )


### PR DESCRIPTION
fixes #89 #97 

We should still use some [standard file conventions](https://github.com/mosdef-hub/reproducibility_study/projects/1#card-67959147) as @CalCraven suggested, but this PR allows for more flexibility when using the analysis functions.