### PR TITLE
Include analysis routines to write sampled data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   rev: 21.8b0
   hooks:
     - id: black
-      args: [--line-length=80]
+      args: [--line-length=80, --target-version=py38]
 - repo: https://github.com/pycqa/isort
   rev: 5.9.3
   hooks:

--- a/reproducibility_project/project-analysis.py
+++ b/reproducibility_project/project-analysis.py
@@ -1,5 +1,6 @@
 """Setup for signac, signac-flow, signac-dashboard for this study."""
 import flow
+import numpy as np
 
 
 class Project(flow.FlowProject):
@@ -10,8 +11,8 @@ class Project(flow.FlowProject):
 
 
 @Project.operation
-@Project.pre(lambda j: j.isfile("trajectory.gsd"))
-def rdf_analysis(job):
+@Project.pre(lambda job: job.isfile("trajectory-npt.gsd"))
+def rdf_npt_analysis(job):
     """Run analysis."""
     from reproducibility_project.src.analysis.rdf import gsd_rdf
 
@@ -20,9 +21,207 @@ def rdf_analysis(job):
 
 
 @Project.operation
-@Project.pre(lambda j: j.isfile("trajectory.gsd"))
-@Project.pre(lambda j: j.isfile("log.txt"))
-def plot_prod_data_with_t0(job):
+@Project.pre(lambda job: job.isfile("trajectory-nvt.gsd"))
+def rdf_nvt_analysis(job):
+    """Run analysis."""
+    from reproducibility_project.src.analysis.rdf import gsd_rdf
+
+    # RDF
+    gsd_rdf(job)
+
+
+@Project.operation
+@Project.pre(lambda job: job.isfile("log-npt.txt"))
+@Project.post(lambda job: job.doc["npt/sampling_results"]["volume"])
+@Project.post(lambda job: job.doc["npt/sampling_results"]["potential_energy"])
+@Project.post(lambda job: job.doc["npt/sampling_results"]["temperature"])
+@Project.post(lambda job: job.doc["npt/sampling_results"]["kinetic_energy"])
+@flow.with_job
+def sample_npt_properties(job):
+    """Write out sampling results for NPT production properties."""
+    from reproducibility_project.src.analysis.sampler import sample_job
+
+    properties = ["volume", "potential_energy", "temperature", "kinetic_energy"]
+    for prop in properties:
+        sample_job(
+            job,
+            ensemble="npt",
+            filename="log-npt.txt",
+            variable=prop,
+            threshold_fraction=0.75,
+            threshold_neff=100,
+        )
+
+
+@Project.operation
+@Project.pre(lambda job: job.isfile("log-nvt.txt"))
+@Project.post(lambda job: job.doc["nvt/sampling_results"]["volume"])
+@Project.post(lambda job: job.doc["nvt/sampling_results"]["potential_energy"])
+@Project.post(lambda job: job.doc["nvt/sampling_results"]["temperature"])
+@Project.post(lambda job: job.doc["nvt/sampling_results"]["kinetic_energy"])
+@flow.with_job
+def sample_nvt_properties(job):
+    """Write out sampling results for NVT production properties."""
+    from reproducibility_project.src.analysis.sampler import sample_job
+
+    properties = ["volume", "potential_energy", "temperature", "kinetic_energy"]
+    for prop in properties:
+        sample_job(
+            job,
+            ensemble="nvt",
+            filename="log-nvt.txt",
+            variable=prop,
+            threshold_fraction=0.75,
+            threshold_neff=100,
+        )
+
+
+@Project.operation
+@Project.pre(lambda job: job.isfile("log-nvt.txt"))
+@Project.post(lambda job: job.doc["nvt/sampling_results"]["volume"])
+@Project.post(lambda job: job.doc["nvt/sampling_results"]["potential_energy"])
+@Project.post(lambda job: job.doc["nvt/sampling_results"]["temperature"])
+@Project.post(lambda job: job.doc["nvt/sampling_results"]["kinetic_energy"])
+@flow.with_job
+def sample_nvt_properties(job):
+    """Write out sampling results for NVT production properties."""
+    from reproducibility_project.src.analysis.sampler import sample_job
+
+    properties = ["volume", "potential_energy", "temperature", "kinetic_energy"]
+    for prop in properties:
+        sample_job(
+            job,
+            ensemble="nvt",
+            filename="log-nvt.txt",
+            variable=prop,
+            threshold_fraction=0.75,
+            threshold_neff=100,
+        )
+
+
+@Project.operation
+@Project.pre(lambda job: job.isfile("log-npt.txt"))
+@Project.pre(lambda job: job.doc["npt/sampling_results"]["volume"])
+@Project.pre(lambda job: job.doc["npt/sampling_results"]["potential_energy"])
+@Project.pre(lambda job: job.doc["npt/sampling_results"]["temperature"])
+@Project.pre(lambda job: job.doc["npt/sampling_results"]["kinetic_energy"])
+@Project.post(lambda job: job.data.get("npt/subsamples/volume", None))
+@Project.post(lambda job: job.data.get("npt/subsamples/potential_energy", None))
+@Project.post(lambda job: job.data.get("npt/subsamples/temperature", None))
+@Project.post(lambda job: job.data.get("npt/subsamples/kinetic_energy", None))
+@flow.with_job
+def write_npt_subsamples(job):
+    """Write subsampled npt property data points to the job.data store."""
+    import pandas as pd
+
+    from reproducibility_project.src.analysis.sampler import (
+        sample_job,
+        write_subsampled_values,
+    )
+
+    my_df = pd.read_csv(job.fn("log-npt.txt"), delim_whitespace=True, header=0)
+    properties = list()
+    for col in my_df.columns:
+        # skip timestep and tps since it will always be correlated data
+        if col == "timestep" or col == "tps":
+            continue
+        else:
+            properties.append(col)
+    for prop in properties:
+        sample_job(
+            job,
+            filename=job.fn("log-npt.txt"),
+            variable=prop,
+            ensemble="npt",
+            threshold_fraction=0.75,
+            threshold_neff=100,
+        )
+
+    for prop in properties:
+        write_subsampled_values(
+            job=job,
+            ensemble="npt",
+            overwrite=True,
+            property=prop,
+            property_filename=job.fn("log-npt.txt"),
+        )
+        with job.data:
+            job.doc[f"{prop}-npt-avg"] = np.mean(
+                job.data[f"npt/subsamples/{prop}"]
+            )
+            job.doc[f"{prop}-npt-std"] = np.std(
+                job.data[f"npt/subsamples/{prop}"]
+            )
+
+
+@Project.operation
+@Project.pre(lambda job: job.isfile("trajectory-nvt.gsd"))
+@Project.pre(lambda job: job.isfile("log-nvt.txt"))
+@Project.post(lambda job: job.data.get("nvt/subsamples/volume", None))
+@Project.post(lambda job: job.data.get("nvt/subsamples/potential_energy", None))
+@Project.post(lambda job: job.data.get("nvt/subsamples/temperature", None))
+@Project.post(lambda job: job.data.get("nvt/subsamples/kinetic_energy", None))
+@flow.with_job
+def write_nvt_properties(job):
+    """Write subsampled nvt property data points to the job.data store."""
+    from reproducibility_project.src.analysis.sampler import sample_job
+
+    properties = ["potential_energy", "temperature", "volume"]
+    for prop in properties:
+        sample_job(
+            job,
+            filename="log-nvt.txt",
+            variable=prop,
+            threshold_fraction=0.75,
+            threshold_neff=100,
+        )
+        with job.data:
+            job.doc[f"{prop}-nvt-avg"] = np.mean(
+                job.data[f"subsamples/{prop}-nvt"]
+            )
+            job.doc[f"{prop}-nvt-std"] = np.std(
+                job.data[f"subsamples/{prop}-nvt"]
+            )
+
+
+@Project.operation
+@Project.pre(lambda job: job.isfile("trajectory-npt.gsd"))
+@Project.pre(lambda job: job.isfile("log-npt.txt"))
+@flow.with_job
+def plot_npt_prod_data_with_t0(job):
+    """Generate plots for production data with t0 as a vertical line."""
+    import pandas as pd
+
+    from reproducibility_project.src.analysis.equilibration import (
+        plot_job_property_with_t0,
+    )
+
+    ensemble = "npt"
+
+    # plot t0
+    df = pd.read_csv(job.fn("log-npt.txt"), delim_whitespace=True, header=0)
+    for prop in df.columns:
+        data_plt_kwarg = {"label": prop}
+        fname = str(prop) + "-" + ensemble + ".png"
+        plot_job_property_with_t0(
+            job,
+            filename=fname,
+            property_name=prop,
+            log_filename="log-npt.txt",
+            title=prop.upper(),
+            overwrite=True,
+            threshold_fraction=0.0,
+            threshold_neff=1,
+            vline_scale=1.1,
+            data_plt_kwargs=data_plt_kwarg,
+        )
+
+
+@Project.operation
+@Project.pre(lambda job: job.isfile("trajectory-nvt.gsd"))
+@Project.pre(lambda job: job.isfile("log-nvt.txt"))
+@flow.with_job
+def plot_nvt_prod_data_with_t0(job):
     """Generate plots for production data with t0 as a vertical line."""
     import pandas as pd
 
@@ -31,17 +230,19 @@ def plot_prod_data_with_t0(job):
     )
 
     # plot t0
-    df = pd.read_csv(job.fn("log.txt"), delim_whitespace=True, header=0)
+    df = pd.read_csv(job.fn("log-nvt.txt"), delim_whitespace=True, header=0)
     for prop in df.columns:
         data_plt_kwarg = {"label": prop}
-        fname = str(prop) + ".png"
+        fname = str(prop) + "-nvt" + ".png"
         plot_job_property_with_t0(
             job,
             filename=fname,
+            log_filename="log-nvt.txt",
             property_name=prop,
             title=prop.upper(),
             overwrite=True,
-            threshold=0.0,
+            threshold_fraction=0.0,
+            threshold_neff=1,
             vline_scale=1.1,
             data_plt_kwargs=data_plt_kwarg,
         )

--- a/reproducibility_project/signac.rc
+++ b/reproducibility_project/signac.rc
@@ -1,3 +1,7 @@
 project = mosdef_reproducibility
 workspace_dir = workspace
 schema_version = 1
+[General]
+[hosts]
+[flow]
+status_parallelization = process

--- a/reproducibility_project/templates/ndcrc_scheduler.py
+++ b/reproducibility_project/templates/ndcrc_scheduler.py
@@ -94,7 +94,7 @@ class SGEScheduler(Scheduler):
         hold=False,
         pretend=False,
         flags=None,
-        **kwargs
+        **kwargs,
     ):
         """Submit a job script for execution to the scheduler.
 

--- a/reproducibility_project/tests/test_sampler.py
+++ b/reproducibility_project/tests/test_sampler.py
@@ -37,19 +37,13 @@ class TestSampler(BaseTest):
             TypeError,
             match=r"Expected input \'job\' of type signac\.contrib\.project\.Job",
         ):
-            write_subsampled_values(
-                "foo",
-                property="density",
-            )
+            write_subsampled_values("foo", property="density", ensemble="npt")
 
         with pytest.raises(
             ValueError,
             match=r"Expected \'property\' to be a name of a property",
         ):
-            write_subsampled_values(
-                tmp_job,
-                property="",
-            )
+            write_subsampled_values(tmp_job, property="", ensemble="npt")
 
         with pytest.raises(
             ValueError,
@@ -63,24 +57,27 @@ class TestSampler(BaseTest):
                 out = out + str(val) + "\n"
             with open(tmp_job.fn("log.txt"), "w") as fp:
                 fp.write(out)
-            tmp_job.data["subsamples/foo"] = np.asarray([1, 2, 3, 4])
-            tmp_job.doc["sampling_results"] = {
+            tmp_job.data["npt/subsamples/foo"] = np.asarray([1, 2, 3, 4])
+            tmp_job.doc["npt/sampling_results"] = {
                 "foo": {"start": 1, "stop": 4, "step": 2, "Neff": 2}
             }
 
-            write_subsampled_values(tmp_job, property="foo", overwrite=False)
+            write_subsampled_values(
+                tmp_job, property="foo", ensemble="npt", overwrite=False
+            )
 
     def test_file_missing(self, tmp_job):
         # by default, the tmp job is missing the file
         with pytest.raises(
             FileNotFoundError, match=r"File missing\.txt does not exist"
         ):
-            tmp_job.doc["sampling_results"] = {
+            tmp_job.doc["npt/sampling_results"] = {
                 "foo": {"start": 1, "stop": 4, "step": 2, "Neff": 2}
             }
             write_subsampled_values(
                 tmp_job,
                 property="foo",
+                ensemble="npt",
                 property_filename="missing.txt",
                 overwrite=False,
             )
@@ -94,12 +91,18 @@ class TestSampler(BaseTest):
             out = out + str(val) + "\n"
         with open(tmp_job.fn("log.txt"), "w") as fp:
             fp.write(out)
-        tmp_job.doc["sampling_results"] = {
+        tmp_job.doc["npt/sampling_results"] = {
             "foo": {"start": 1, "stop": 4, "step": 1, "Neff": 4}
         }
-        write_subsampled_values(tmp_job, property="foo", overwrite=False)
+        write_subsampled_values(
+            tmp_job,
+            property="foo",
+            property_filename="log.txt",
+            ensemble="npt",
+            overwrite=False,
+        )
         with tmp_job.data:
-            assert len(tmp_job.data["subsamples/foo"]) == 3
+            assert len(tmp_job.data["npt/subsamples/foo"]) == 3
             np.testing.assert_array_equal(
-                tmp_job.data["subsamples/foo"], [2, 3, 4]
+                tmp_job.data["npt/subsamples/foo"], [2, 3, 4]
             )


### PR DESCRIPTION
Currently, we have utilities to subsample the properties of interest for
statistical treatment, however, we have not implemented this in our
analysis signac project.

This is the initial addition of these routines for both NPT and NVT
production data.

Additional unit tests are needed, as well as further normalization of
the data between each engine (specifically column names), but since we
have the data for methane manually calculated, this should be a great
way to test this.