### PR TITLE
Remove extraneous temperatures and pressure from subproject-init.py

### DIFF
--- a/reproducibility_project/lrc_shift_subproject/subproject-init.py
+++ b/reproducibility_project/lrc_shift_subproject/subproject-init.py
@@ -63,24 +63,24 @@ temperatures = {
     "methaneUA": [140.0] * u.K,
     "pentaneUA": [372.0] * u.K,
     "benzeneUA": [450.0] * u.K,
-    "waterSPCE": [280.0, 300.0, 320.0] * u.K,
-    "ethanolAA": [280.0, 300.0, 320.0] * u.K,
+    "waterSPCE": [300.0] * u.K,
+    "ethanolAA": [300.0] * u.K,
 }
 
 pressures = {
     "methaneUA": [1318.0] * u.kPa,
     "pentaneUA": [1402.0] * u.kPa,
     "benzeneUA": [2260.0] * u.kPa,
-    "waterSPCE": [101.325, 101.325, 101.325] * u.kPa,
-    "ethanolAA": [101.325, 101.325, 101.325] * u.kPa,
+    "waterSPCE": [101.325] * u.kPa,
+    "ethanolAA": [101.325] * u.kPa,
 }
 
 N_liq_molecules = {
     "methaneUA": [900],
     "pentaneUA": [300],
     "benzeneUA": [400],
-    "waterSPCE": [2000, 2000, 2000],
-    "ethanolAA": [700, 700, 700],
+    "waterSPCE": [2000],
+    "ethanolAA": [700],
 }
 
 N_vap_molecules = {


### PR DESCRIPTION
As the title states, we don't need to run extra temperatures for ethanolAA and waterspc/e. These have been removed, which gives a total of 192 simulations run for each engine now.

3 molecules X 4 lrc/cutoff_style X 16 replicates.