### PR TITLE
Remove statepoints with LRC and shifted potentials

### DIFF
--- a/reproducibility_project/lrc_shift_subproject/subproject-init.py
+++ b/reproducibility_project/lrc_shift_subproject/subproject-init.py
@@ -205,6 +205,13 @@ for i, sp in enumerate(total_statepoints):
     if sp["ensemble"] == "GEMC-NVT" and sp["engine"] in md_engines:
         indices_to_remove.add(i)
 
+    # does not make sense to use a shifted potential with LRC
+    if (
+        sp["long_range_correction"] == "energy_pressure"
+        and sp["cutoff_style"] == "shift"
+    ):
+        indices_to_remove.add(i)
+
     # hoomd-blue does not have long range correction
     if sp["engine"] == "hoomd":
         if sp["long_range_correction"] is not None:


### PR DESCRIPTION
It does not make sense to run a simulation with both long range
corrections and shifted potentials at the same time, in fact, [LAMMPS
forbids this entirely](https://docs.lammps.org/pair_modify.html#restrictions).

LRC's are meant to be used when there are discontinuities at the cutoff,
and shifted potentials are meant to transition the potential to 0 at the
cutoff. These attempt to mitigate similar issues.