### PR TITLE
Update null value from None to "None" string

### DIFF
--- a/reproducibility_project/lrc_shift_subproject/subproject-init.py
+++ b/reproducibility_project/lrc_shift_subproject/subproject-init.py
@@ -23,7 +23,7 @@ mc_engines = ["cassandra", "mcccs", "gomc"]
 forcefields = {}
 r_cuts = {}
 cutoff_styles = ["hard", "shift"]
-long_range_correction = [None, "energy_pressure"]
+long_range_correction = ["None", "energy_pressure"]
 for key in molecules:
     if "UA" in key:
         if "benz" not in key:
@@ -214,7 +214,7 @@ for i, sp in enumerate(total_statepoints):
 
     # hoomd-blue does not have long range correction
     if sp["engine"] == "hoomd":
-        if sp["long_range_correction"] is not None:
+        if sp["long_range_correction"] != "None":
             indices_to_remove.add(i)
 
     if sp["ensemble"] == "NPT":


### PR DESCRIPTION
When trying to aggregate jobs according to various statepoint values, if
a `NoneType` value is used to represent that value not being necessary,
trying to aggregate jobs according to statepoints that have `NoneType`
as an option will fail due to the call of the `sort` method.

This makes it not possible to easily aggreate jobs when trying to do
final statistical analyses of our systems. This changes the default null
value to "None" string instead of `None`.