### PR TITLE
benzene FF update.  Found 1.00066 x scaler issue.

### DIFF
--- a/reproducibility_project/src/xmls/benzene_trappe-ua_like.xml
+++ b/reproducibility_project/src/xmls/benzene_trappe-ua_like.xml
@@ -3,7 +3,7 @@
   <Type name="CH_sp2" class="CH_E" element="_CH" mass="13.01900" def="[_CH;X2]([_CH,C])[_CH,C]" desc="Aromatic CH group (eg. benzene), united atom. These are the same parameters that are on the http://trappe.oit.umn.edu website, but on the website they have all fixed bonds, angles and no dihedrals." doi="10.1016/j.fluid.2018.07.001"/>
  </AtomTypes>
  <HarmonicBondForce>
-  <Bond class1="CH_E" class2="CH_E" length="0.14" k="392721.84"/>
+  <Bond class1="CH_E" class2="CH_E" length="0.14" k="392459.2"/>
  </HarmonicBondForce>
  <HarmonicAngleForce>
   <Angle class1="CH_E" class2="CH_E" class3="CH_E" angle="2.0943951023932" k="527.178502304004"/>


### PR DESCRIPTION
The benzene FF was update with the very slightly altered FF parameters 

The source of the error. My TI-89 provides the wrong unit conversion for kcal to kJ. being 4.1868 which should be 4.184. Therefore, I think the calculation in this software are spot on. This is the first error I found in my TI-89!!

See https://github.com/mosdef-hub/foyer/issues/448 for more info.  