### PR TITLE
WSU/GOMC grid.sh slurm script now only allows use of 1 node per job

### DIFF
--- a/reproducibility_project/templates/grid.sh
+++ b/reproducibility_project/templates/grid.sh
@@ -13,6 +13,7 @@
 #SBATCH --constraint=intel
 {%- endif %}
 
+#SBATCH -N 1
 #SBATCH --mail-type=ALL
 #SBATCH --mail-user=xxxx@wayne.edu
 #SBATCH -o output-%j.dat


### PR DESCRIPTION
Added a line to only allow  1 node per job for the GOMC jobs