### PR TITLE
removed email section from the gomc/WSU grid.sh file as if not filled out it errors out.

### DIFF
--- a/reproducibility_project/templates/grid.sh
+++ b/reproducibility_project/templates/grid.sh
@@ -15,7 +15,6 @@
 
 #SBATCH -N 1
 #SBATCH --mail-type=ALL
-#SBATCH --mail-user=xxxx@wayne.edu
 #SBATCH -o output-%j.dat
 #SBATCH -e error-%j.dat
 


### PR DESCRIPTION
removed email section from the gomc/WSU grid.sh file as if not filled out it errors out.