### PR TITLE
Modify pentaneUA statepoints for flexible and constrained

### DIFF
--- a/reproducibility_project/init.py
+++ b/reproducibility_project/init.py
@@ -15,7 +15,14 @@ def dict_product(dd):
         yield dict(zip(keys, element))
 
 
-molecules = ["methaneUA", "pentaneUA-flexible_bonds", "pentaneUA-constrain_bonds", "benzeneUA", "waterSPCE", "ethanolAA"]
+molecules = [
+    "methaneUA",
+    "pentaneUA-flexible_bonds",
+    "pentaneUA-constrain_bonds",
+    "benzeneUA",
+    "waterSPCE",
+    "ethanolAA",
+]
 replicas = range(16)
 simulation_engines = [
     "cassandra",
@@ -230,12 +237,17 @@ for i, sp in enumerate(total_statepoints):
 
     if sp["ensemble"] is None:
         indices_to_remove.add(i)
-    
-    if sp["engine"] in mc_engines and sp["molecule"] == "pentaneUA-flexible_bonds":
+
+    if (
+        sp["engine"] in mc_engines
+        and sp["molecule"] == "pentaneUA-flexible_bonds"
+    ):
         indices_to_remove.add(i)
-    if "lammps" in sp["engine"] and sp["molecule"] == "pentaneUA-constrain_bonds":
+    if (
+        "lammps" in sp["engine"]
+        and sp["molecule"] == "pentaneUA-constrain_bonds"
+    ):
         indices_to_remove.add(i)
-        
 
 
 # now reverse sort the set and remove from inital list

--- a/reproducibility_project/init.py
+++ b/reproducibility_project/init.py
@@ -15,7 +15,7 @@ def dict_product(dd):
         yield dict(zip(keys, element))
 
 
-molecules = ["methaneUA", "pentaneUA", "benzeneUA", "waterSPCE", "ethanolAA"]
+molecules = ["methaneUA", "pentaneUA-flexible_bonds", "pentaneUA-constrain_bonds", "benzeneUA", "waterSPCE", "ethanolAA"]
 replicas = range(16)
 simulation_engines = [
     "cassandra",
@@ -48,28 +48,32 @@ for key in molecules:
 g_per_cm3 = u.g / (u.cm * u.cm * u.cm)
 masses = {
     "methaneUA": [16.04] * u.amu,
-    "pentaneUA": [72.15] * u.amu,
+    "pentaneUA-flexible_bonds": [72.15] * u.amu,
+    "pentaneUA-constrain_bonds": [72.15] * u.amu,
     "benzeneUA": [78.1118] * u.amu,
     "waterSPCE": [18.0153] * u.amu,
     "ethanolAA": [46.0684] * u.amu,
 }
 init_density_liq = {
     "methaneUA": [0.3752] * g_per_cm3,
-    "pentaneUA": [0.5390] * g_per_cm3,
+    "pentaneUA-flexible_bonds": [0.5390] * g_per_cm3,
+    "pentaneUA-constrain_bonds": [0.5390] * g_per_cm3,
     "benzeneUA": [0.692] * g_per_cm3,
     "waterSPCE": [0.998] * g_per_cm3,
     "ethanolAA": [0.7893] * g_per_cm3,
 }
 init_density_vap = {
     "methaneUA": [0.0117] * g_per_cm3,
-    "pentaneUA": [0.019] * g_per_cm3,
+    "pentaneUA-flexible_bonds": [0.019] * g_per_cm3,
+    "pentaneUA-constrain_bonds": [0.019] * g_per_cm3,
     "benzeneUA": [None],
     "waterSPCE": [None],
     "ethanolAA": [None],
 }
 temperatures = {
     "methaneUA": [140.0] * u.K,
-    "pentaneUA": [372.0] * u.K,
+    "pentaneUA-flexible_bonds": [372.0] * u.K,
+    "pentaneUA-constrain_bonds": [372.0] * u.K,
     "benzeneUA": [450.0] * u.K,
     "waterSPCE": [280.0, 300.0, 320.0] * u.K,
     "ethanolAA": [280.0, 300.0, 320.0] * u.K,
@@ -77,7 +81,8 @@ temperatures = {
 
 pressures = {
     "methaneUA": [1318.0] * u.kPa,
-    "pentaneUA": [1402.0] * u.kPa,
+    "pentaneUA-flexible_bonds": [1402.0] * u.kPa,
+    "pentaneUA-constrain_bonds": [1402.0] * u.kPa,
     "benzeneUA": [2260.0] * u.kPa,
     "waterSPCE": [101.325, 101.325, 101.325] * u.kPa,
     "ethanolAA": [101.325, 101.325, 101.325] * u.kPa,
@@ -85,7 +90,8 @@ pressures = {
 
 N_liq_molecules = {
     "methaneUA": [900],
-    "pentaneUA": [300],
+    "pentaneUA-flexible_bonds": [300],
+    "pentaneUA-constrain_bonds": [300],
     "benzeneUA": [400],
     "waterSPCE": [1100, 1100, 1100],
     "ethanolAA": [500, 500, 500],
@@ -93,7 +99,8 @@ N_liq_molecules = {
 
 N_vap_molecules = {
     "methaneUA": [100],
-    "pentaneUA": [100],
+    "pentaneUA-flexible_bonds": [100],
+    "pentaneUA-constrain_bonds": [100],
     "benzeneUA": [None],
     "waterSPCE": [None],
     "ethanolAA": [None],
@@ -101,7 +108,8 @@ N_vap_molecules = {
 
 liq_box_lengths = {
     "methaneUA": [39.98] * u.angstrom,
-    "pentaneUA": [40.55] * u.angstrom,
+    "pentaneUA-flexible_bonds": [40.55] * u.angstrom,
+    "pentaneUA-constrain_bonds": [40.55] * u.angstrom,
     "benzeneUA": [42.17] * u.angstrom,
     "waterSPCE": [32.07] * u.angstrom,
     "ethanolAA": [36.46] * u.angstrom,
@@ -109,7 +117,8 @@ liq_box_lengths = {
 
 vap_box_lengths = {
     "methaneUA": [61.06] * u.angstrom,
-    "pentaneUA": [85.75] * u.angstrom,
+    "pentaneUA-flexible_bonds": [85.75] * u.angstrom,
+    "pentaneUA-constrain_bonds": [85.75] * u.angstrom,
     "benzeneUA": [None],
     "waterSPCE": [None],
     "ethanolAA": [None],
@@ -117,7 +126,8 @@ vap_box_lengths = {
 
 ensembles = {
     "methaneUA": ["NPT", "GEMC-NVT"],
-    "pentaneUA": ["NPT", "GEMC-NVT"],
+    "pentaneUA-flexible_bonds": ["NPT", "GEMC-NVT"],
+    "pentaneUA-constrain_bonds": ["NPT", "GEMC-NVT"],
     "benzeneUA": ["NPT", None],
     "waterSPCE": ["NPT", None],
     "ethanolAA": ["NPT", None],
@@ -220,6 +230,12 @@ for i, sp in enumerate(total_statepoints):
 
     if sp["ensemble"] is None:
         indices_to_remove.add(i)
+    
+    if sp["engine"] in mc_engines and sp["molecule"] == "pentaneUA-flexible_bonds":
+        indices_to_remove.add(i)
+    if "lammps" in sp["engine"] and sp["molecule"] == "pentaneUA-constrain_bonds":
+        indices_to_remove.add(i)
+        
 
 
 # now reverse sort the set and remove from inital list

--- a/reproducibility_project/src/molecules/system_builder.py
+++ b/reproducibility_project/src/molecules/system_builder.py
@@ -131,6 +131,8 @@ def get_molecule(sp):
     """
     molecule_dict = {
         "methaneUA": MethaneUA(),
+        "pentaneUA-flexible_bonds": PentaneUA(),
+        "pentaneUA-constrain_bonds": PentaneUA(),
         "pentaneUA": PentaneUA(),
         "benzeneUA": BenzeneUA(),
         "waterSPCE": WaterSPC(),


### PR DESCRIPTION
In order to compare between MD and MC treatments of pentaneUA, we need to have both rigid and flexible models for pentaneUA.

	*Lammps-VU and lammps-UD can not do constrained bonds
	*All MC engines and HOOMD + Gromacs can do constrained bonds
	*All MC engines cannot do flexible bonds
	*All MD engines can do flexible bonds

This PR updates the statepoints from init.py with two pentane "molecules"; 1 that will be treated flexibly, and one that will be treated constrained.