### PR TITLE
Fix Cassandra mixing rule and make benzene rigid

### DIFF
--- a/reproducibility_project/src/engines/cassandra/project.py
+++ b/reproducibility_project/src/engines/cassandra/project.py
@@ -253,12 +253,12 @@ def run_cassandra(job):
         else:
             p_translate = 0.7
             p_swap = 0.29
-    elif molecule == "pentaneUA" and ensemble == "GEMC-NVT":
+    elif "pentaneUA" in molecule and ensemble == "GEMC-NVT":
         p_swap = 0.2
         p_translate = 0.27
         p_rotate = 0.26
         p_regrow = 0.26
-    elif molecule == "waterSPCE":
+    elif molecule == "waterSPCE" or molecule == "benzeneUA":
         p_translate = 0.49
         p_rotate = 0.5
     else:
@@ -292,6 +292,7 @@ def run_cassandra(job):
                 charge_style=charge_style,
                 vdw_cutoff=cutoff,
                 charge_cutoff=cutoff,
+                mixing_rule=comb_rule,
                 run_name="nvt_melt",
                 prop_freq=prop_freq,
                 coord_freq=5000,
@@ -318,6 +319,7 @@ def run_cassandra(job):
                 charge_style=charge_style,
                 vdw_cutoff=cutoff,
                 charge_cutoff=cutoff,
+                mixing_rule=comb_rule,
                 run_name="nvt_equil",
                 prop_freq=prop_freq,
                 coord_freq=5000,
@@ -345,6 +347,7 @@ def run_cassandra(job):
                     charge_style=charge_style,
                     vdw_cutoff=cutoff,
                     charge_cutoff=cutoff,
+                    mixing_rule=comb_rule,
                     run_name="nvt_melt_vap",
                     prop_freq=prop_freq,
                     coord_freq=5000,
@@ -368,6 +371,7 @@ def run_cassandra(job):
                     charge_style=charge_style,
                     vdw_cutoff=cutoff,
                     charge_cutoff=cutoff,
+                    mixing_rule=comb_rule,
                     run_name="nvt_equil_vap",
                     prop_freq=prop_freq,
                     coord_freq=5000,
@@ -400,6 +404,7 @@ def run_cassandra(job):
                 charge_style=charge_style,
                 vdw_cutoff=cutoff,
                 charge_cutoff=cutoff,
+                mixing_rule=comb_rule,
                 run_name=this_run,
                 prop_freq=prop_freq,
                 coord_freq=coord_freq,


### PR DESCRIPTION
Also account for new pentane naming.

Previously, the mixing rule was accidentally left as default (Lorentz-Berthelot).  This PR applies the geometric combining rule when appropriate (currently only needed for ethanol).