### PR TITLE
Rerun spe data parsed from log.txt to get correct headings

### DIFF
--- a/reproducibility_project/spe_subproject/README.md
+++ b/reproducibility_project/spe_subproject/README.md
@@ -18,7 +18,7 @@ The following energy definitions are calculated using the [lammps thermo](https:
 * potential_energy = pe </br>
 * tot_vdw_energy = evdwl </br>
 * tail_energy = etail </br>
-* tot_electrostatics = elong </br>
+* tot_electrostatics = elong + ecoul</br>
 * short_range_electrostatics = ecoul </br>
 * long_range_electrostatics = elong </br>
 * tot_pair_energy = epair </br>

--- a/reproducibility_project/spe_subproject/src/engines/lammps-VU/project.py
+++ b/reproducibility_project/spe_subproject/src/engines/lammps-VU/project.py
@@ -168,20 +168,35 @@ def FormatTextFile(job):
     ]
     new_titles_list = [
         "potential_energy",
-        "vdw_energy",
-        "coul_energy",
+        "tot_vdw_energy",
+        "short_range_electrostatics",
         "pair_energy",
         "bonds_energy",
         "angles_energy",
         "dihedrals_energy",
         "tail_energy",
-        "kspace_energy",
+        "long_range_electrostatics",
     ]
     # convert units
     KCAL_TO_KJ = 4.184  # kcal to kj
     df_in = df_in * KCAL_TO_KJ
     df_out = df_in[attr_list]
     df_out.columns = new_titles_list
+    # calculate new values
+    df_out["tot_electrostatics"] = (
+        df_out["short_range_electrostatics"]
+        + df_out["long_range_electrostatics"]
+    )
+    df_out["tot_bonded_energy"] = (
+        df_out["bonds_energy"]
+        + df_out["angles_energy"]
+        + df_out["dihedrals_energy"]
+    )
+    df_out["tot_pair_energy"] = (
+        df_out["tot_vdw_energy"] + df_out["tot_electrostatics"]
+    )
+    df_out["intramolecular_energy"] = None
+    df_out["intermolecular_energy"] = None
     df_out.to_csv("log-spe.txt", header=True, index=False, sep=",")
 
 

--- a/reproducibility_project/spe_subproject/workspace/0e89e47e0b8386c5e0cb6741b6a43ddd/log-spe.txt
+++ b/reproducibility_project/spe_subproject/workspace/0e89e47e0b8386c5e0cb6741b6a43ddd/log-spe.txt
@@ -1,2 +1,2 @@
-potential_energy,vdw_energy,coul_energy,pair_energy,bonds_energy,angles_energy,dihedrals_energy,tail_energy,kspace_energy
-388924.22364089265,388924.2235790427,0.0,388924.2235790427,6.02877287576594e-05,1.522308140204045e-06,3.9923977221445445e-08,-250.54916165210687,0.0
+potential_energy,tot_vdw_energy,short_range_electrostatics,pair_energy,bonds_energy,angles_energy,dihedrals_energy,tail_energy,long_range_electrostatics,tot_electrostatics,tot_bonded_energy,tot_pair_energy,intramolecular_energy,intermolecular_energy
+388924.22364089265,388924.2235790427,0.0,388924.2235790427,6.02877287576594e-05,1.522308140204045e-06,3.9923977221445445e-08,-250.54916165210687,0.0,0.0,6.184996087508489e-05,388924.2235790427,,

--- a/reproducibility_project/spe_subproject/workspace/10fd6a71341374749234dd646175d3f8/log-spe.txt
+++ b/reproducibility_project/spe_subproject/workspace/10fd6a71341374749234dd646175d3f8/log-spe.txt
@@ -1,2 +1,2 @@
-potential_energy,vdw_energy,coul_energy,pair_energy,bonds_energy,angles_energy,dihedrals_energy,tail_energy,kspace_energy
-536743.5537731947,536743.5537731947,0.0,536743.5537731947,0.0,0.0,0.0,-128.23123468785766,0.0
+potential_energy,tot_vdw_energy,short_range_electrostatics,pair_energy,bonds_energy,angles_energy,dihedrals_energy,tail_energy,long_range_electrostatics,tot_electrostatics,tot_bonded_energy,tot_pair_energy,intramolecular_energy,intermolecular_energy
+536743.5537731947,536743.5537731947,0.0,536743.5537731947,0.0,0.0,0.0,-128.23123468785766,0.0,0.0,0.0,536743.5537731947,,

--- a/reproducibility_project/spe_subproject/workspace/97012c1605506c345df167c80b27f12e/log-spe.txt
+++ b/reproducibility_project/spe_subproject/workspace/97012c1605506c345df167c80b27f12e/log-spe.txt
@@ -1,2 +1,2 @@
-potential_energy,vdw_energy,coul_energy,pair_energy,bonds_energy,angles_energy,dihedrals_energy,tail_energy,kspace_energy
-31409.503929307408,19408.270670300964,81265.61265888733,22983.60195288422,5.9652454519500356e-05,7233.270516470011,1192.6314003007387,-417.8757523306034,-77690.28137630383
+potential_energy,tot_vdw_energy,short_range_electrostatics,pair_energy,bonds_energy,angles_energy,dihedrals_energy,tail_energy,long_range_electrostatics,tot_electrostatics,tot_bonded_energy,tot_pair_energy,intramolecular_energy,intermolecular_energy
+31409.503929307408,19408.270670300964,81265.61265888733,22983.60195288422,5.9652454519500356e-05,7233.270516470011,1192.6314003007387,-417.8757523306034,-77690.28137630383,3575.331282583502,8425.901976423203,22983.601952884466,,

--- a/reproducibility_project/spe_subproject/workspace/dfa90c3824da921ada9cf8439145a05f/log-spe.txt
+++ b/reproducibility_project/spe_subproject/workspace/dfa90c3824da921ada9cf8439145a05f/log-spe.txt
@@ -1,2 +1,2 @@
-potential_energy,vdw_energy,coul_energy,pair_energy,bonds_energy,angles_energy,dihedrals_energy,tail_energy,kspace_energy
-57176.38530082049,76663.71351238873,292697.83809846675,57176.38530082049,0.0,0.0,0.0,-275.65101326646686,-312185.166310035
+potential_energy,tot_vdw_energy,short_range_electrostatics,pair_energy,bonds_energy,angles_energy,dihedrals_energy,tail_energy,long_range_electrostatics,tot_electrostatics,tot_bonded_energy,tot_pair_energy,intramolecular_energy,intermolecular_energy
+57176.38530082049,76663.71351238873,292697.83809846675,57176.38530082049,0.0,0.0,0.0,-275.65101326646686,-312185.166310035,-19487.328211568238,0.0,57176.38530082049,,

--- a/reproducibility_project/spe_subproject/workspace/f95937fb2c289f423cae5221956d8092/log-spe.txt
+++ b/reproducibility_project/spe_subproject/workspace/f95937fb2c289f423cae5221956d8092/log-spe.txt
@@ -1,2 +1,2 @@
-potential_energy,vdw_energy,coul_energy,pair_energy,bonds_energy,angles_energy,dihedrals_energy,tail_energy,kspace_energy
-537739.1201412209,537739.1201406015,0.0,537739.1201406015,5.538203280251401e-07,6.262974415313544e-08,2.922457877532078e-09,-181.1080840640345,0.0
+potential_energy,tot_vdw_energy,short_range_electrostatics,pair_energy,bonds_energy,angles_energy,dihedrals_energy,tail_energy,long_range_electrostatics,tot_electrostatics,tot_bonded_energy,tot_pair_energy,intramolecular_energy,intermolecular_energy
+537739.1201412209,537739.1201406015,0.0,537739.1201406015,5.538203280251401e-07,6.262974415313544e-08,2.922457877532078e-09,-181.1080840640345,0.0,0.0,6.193725300558077e-07,537739.1201406015,,


### PR DESCRIPTION
LAMMPS data was considering the total electrostatics incorrectly. This fixes it.